### PR TITLE
Adjusts button component layout

### DIFF
--- a/src/components/button-link/editor.scss
+++ b/src/components/button-link/editor.scss
@@ -4,5 +4,18 @@
 // Additional styles necessary to assist the editor.
 // Enqueued after style.scss.
 //--------------------------------------------------------------
-.wds-button-options {
-} // .wds-button-options
+.editor-block-list__layout {
+
+	.button.wds-button-component {
+		background-color: transparent;
+		border: none;
+		box-shadow: none;
+		height: unset;
+		padding: 0;
+
+		textarea,
+		form {
+			padding: 0 10px;
+		} // textarea, form
+	} // .button.wds-button-component
+} // .editor-block-list__layout

--- a/src/components/button-link/editor.scss
+++ b/src/components/button-link/editor.scss
@@ -11,6 +11,7 @@
 		border: none;
 		box-shadow: none;
 		height: unset;
+		max-width: 280px;
 		padding: 0;
 
 		textarea,

--- a/src/components/button-link/index.js
+++ b/src/components/button-link/index.js
@@ -36,7 +36,7 @@ export default class ButtonLink extends Component {
 
 	render() {
 		return (
-			<Button className={ 'button button-large' }>
+			<Button className={ 'button wds-button-component button-large' }>
 				<PlainText
 					value={ this.props.attributes.buttonText }
 					placeholder={


### PR DESCRIPTION
Closes #33

### DESCRIPTION ###
Adjusts the styles for the button component so that it does not break out of its parent container.

### SCREENSHOTS ###
![](https://dl.dropbox.com/s/eo0lf6688wjrmrs/Screenshot%202018-03-23%2015.24.08.jpg?dl=0)

### OTHER ###
- [x] Is this issue accessible? (Section 508/WCAG 2.0AA)
- [x] Does this issue pass linting? (ESLint)

### STEPS TO VERIFY ###
Add a Hero or CTA block and compare to the previous layout:
![](https://dl.dropbox.com/s/h2isxzbn6wtswwa/Screenshot%202018-03-23%2015.21.20.jpg?dl=0)

### DOCUMENTATION ###
Will this pull request require updating the WDS Gutenberg [wiki](https://github.com/WebDevStudios/wds-gutenberg/wiki)?
Nah - this just adds some editor styles to resolve the layout issue.