### PR TITLE
Feature/#27 bring in prettier

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,11 @@
+{
+  "useTabs": true,
+  "printWidth": 80,
+  "tabWidth": 4,
+  "singleQuote": true,
+  "trailingComma": "all",
+  "jsxBracketSameLine": true,
+  "parser": "babylon",
+  "noSemi": false,
+  "rcVerbose": true
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -4982,6 +4982,11 @@
       "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
       "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks="
     },
+    "prettier": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.11.1.tgz",
+      "integrity": "sha512-T/KD65Ot0PB97xTrG8afQ46x3oiVhnfGjGESSI9NWYcG92+OUPZKkwHqGWXH2t9jK1crnQjubECW0FuOth+hxw=="
+    },
     "private": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "cgb-scripts": "1.9.4",
     "classnames": "^2.2.5",
-    "jsonp": "^0.2.1"
+    "jsonp": "^0.2.1",
+    "prettier": "^1.11.1"
   }
 }


### PR DESCRIPTION
Closes #27

### DESCRIPTION ###
Add prettier.io as dev dependencies and added config file `.prettierrc`.

The config (sans comments) was added as follows:

``` 
{
    "useTabs": true,         // Indent lines with tabs instead of spaces.
    "printWidth": 80,       // Specify the length of line that the printer will wrap on.
    "tabWidth": 4,            // Specify the number of spaces per indentation-level.
    "singleQuote": true,  // Use single quotes instead of double quotes.
    /**
     * Print trailing commas wherever possible.
     * Valid options:
     *   - "none" - no trailing commas
     *   - "es5" - trailing commas where valid in ES5 (objects, arrays, etc)
     *   - "all" - trailing commas wherever possible (function arguments)
     */
    "trailingComma": "all",
    /**
     * Do not print spaces between brackets.
     * If true, puts the > of a multi-line jsx element at the end of the last line instead of being
     * alone on the next line
     */
    "jsxBracketSameLine": false,
    /**
     * Specify which parse to use.
     * Valid options:
     *   - "flow"
     *   - "babylon"
     */
    "parser": "babylon",
    /**
     * Do not print semicolons, except at the beginning of lines which may need them.
     * Valid options:
     * - true - add a semicolon at the end of every line
     * - false - only add semicolons at the beginning of lines that may introduce ASI failures
     */
    "noSemi": false,
    /**
     * Add additional logging from prettierrc (not prettier itself).
     * Defaults to false
     * Valid options:
     * - true - enable additional logging
     * - false - disable additional logging
     */
    "rcVerbose": true
}
```

![kapture 2018-04-10 at 12 19 53](https://user-images.githubusercontent.com/5230729/38575797-873649b4-3cb9-11e8-90e5-18f7dd3033b2.gif)
